### PR TITLE
Otimizações no Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
 FROM ubuntu
-
-RUN apt-get update && apt-get install -y python3.6 python3-pip
-RUN apt-get install --assume-yes git
-RUN pip3 install setuptools pip --upgrade --force-reinstall
-
 WORKDIR /usr/src/app
-
-RUN git clone https://github.com/eaglebh/blast-dbf.git
-RUN cd blast-dbf && make
-
-COPY requirements.txt /usr/src/app/requirements.txt
-COPY dbc2dbf.sh /usr/src/app/dbc2dbf.sh
-COPY dbf2csv.py /usr/src/app/dbf2csv.py
-COPY Makefile /usr/src/app/Makefile
-
-RUN pip3 install -r requirements.txt
+COPY ["requirements.txt", "dbc2dbf.sh", "dbf2csv.py", "Makefile", "./"]
+RUN apt-get update && \
+    apt-get install --assume-yes python3 python3-pip git && \
+    pip3 install setuptools pip --upgrade --force-reinstall && \
+    git clone https://github.com/eaglebh/blast-dbf.git && \
+    cd blast-dbf && \
+    make && \
+    pip3 install -r ../requirements.txt

--- a/dbf2csv.py
+++ b/dbf2csv.py
@@ -3,6 +3,6 @@ from simpledbf import Dbf5
 
 for file in os.listdir("data"):
         if file.endswith(".dbf"):
-                dbf = Dbf5("data/" + file, codec='latin-1')
+                dbf = Dbf5("data/" + file, codec='utf-8')
                 dbf.to_csv("data/csv/" + os.path.splitext(file)[0] + ".csv")
                 print("data/" + file + " converted to csv")


### PR DESCRIPTION
Quando trabalhamos com Dockerfile, é uma boa pratica unificar o máximo de comandos possíveis.

Isso implica em uma maior legibilidade e entendimento do código, além de que durante o build cada linha do Dockerfile cria um snapshot da imagem que está sendo gerada, assim se por ventura falhar o build recomeçara do ultimo snapshot completo... Apesar de ser benéfico, quando existem muitos snapshots de uma mesma imagem um grande espaço do disco é perdido por conta desses backups.


Referencias : [Docs - Dockerfile Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)